### PR TITLE
fix for api card description, date and width

### DIFF
--- a/src/components/APILayout.tsx
+++ b/src/components/APILayout.tsx
@@ -6,7 +6,6 @@ import DevAPICard from "./DevAPICard";
 
 const APILayout: React.FC = () => {
   const { userApis } = useAppSelector((store) => store.user);
-  console.log(userApis);
   const classes = useStyles();
   const PER_PAGE = 6;
   const count = Math.ceil(userApis.length / PER_PAGE);

--- a/src/components/DevAPICard.tsx
+++ b/src/components/DevAPICard.tsx
@@ -128,10 +128,10 @@ const DevAPICard: React.FC<CardProps> = ({
                 <Typography
                   variant="h5"
                   component="div"
-                  sx={{ fontSize: "18px", fontWeight: "500", mb: 1 }}>
+                  sx={{fontSize: "16px", fontWeight: "500", mb: 1}}>
                   {name || "👋 Onboarding Project"}
                 </Typography>
-                <Typography variant="body2" sx={{ mb: 2 }}>
+                <Typography variant="body2" sx={{fontSize: "14px", mb: 2}}>
                   {
                     description.length > 100 ? `${description.substring(0, 100)}...`
                     : description || "This project is created by the onboarding process "
@@ -143,7 +143,7 @@ const DevAPICard: React.FC<CardProps> = ({
               variant="subtitle1"
               sx={{ margin: 1.5, marginLeft: 2.5 }}
               color="text.secondary">
-              {createdOn && new Date(createdOn).toLocaleDateString() || "Updated"}
+                Created: {createdOn && new Date(createdOn).toLocaleDateString() || "Updated"}
                 {/* or new Date(date).toDateString() : this will include the day */}
             </Typography>
           </React.Fragment>
@@ -154,7 +154,12 @@ const DevAPICard: React.FC<CardProps> = ({
 };
 
 const useStyles = makeStyles({
-  paper: {},
+  paper: {
+    transition: "all 0.5s ease-in-out",
+    "&:hover": {
+      boxShadow: "5px 5px 15px 0px rgba(0, 0, 0, 0.4)",
+    }
+  },
   card: {
     width: "100%",
     height: "100%"

--- a/src/components/DevAPICard.tsx
+++ b/src/components/DevAPICard.tsx
@@ -141,9 +141,9 @@ const DevAPICard: React.FC<CardProps> = ({
             </CardContent>
             <Typography
               variant="subtitle1"
-              sx={{ margin: 1.5, marginLeft: 2.5 }}
+              sx={{margin: 1.5, marginLeft: 2.5, fontSize: "14px"}}
               color="text.secondary">
-                Created: {createdOn && new Date(createdOn).toLocaleDateString() || "Updated"}
+                created: {createdOn && new Date(createdOn).toLocaleDateString() || "Updated"}
                 {/* or new Date(date).toDateString() : this will include the day */}
             </Typography>
           </React.Fragment>

--- a/src/components/DevAPICard.tsx
+++ b/src/components/DevAPICard.tsx
@@ -83,9 +83,9 @@ const DevAPICard: React.FC<CardProps> = ({
   };
 
   return (
-    <Paper className={classes.paper} sx={{ minWidth: "395px"}}>
-      <Box sx={{ minWidth: "395px"}}>
-        <Card variant="outlined">
+    <Paper className={classes.paper} sx={{width:"395px", height:"255px"}}>
+      <Box sx={{width:"100%", height:"100%"}}>
+        <Card variant="outlined" className={classes.card}>
           <React.Fragment>
             <CardContent>
               <CardHeader
@@ -124,7 +124,7 @@ const DevAPICard: React.FC<CardProps> = ({
                 </MenuItem>
               </Menu>
 
-              <Link to={`/developer/api/${id}`}>
+              <Link to={`/developer/api/${id}`} style={{color: "#081F4A"}}>
                 <Typography
                   variant="h5"
                   component="div"
@@ -133,7 +133,7 @@ const DevAPICard: React.FC<CardProps> = ({
                 </Typography>
                 <Typography variant="body2" sx={{ mb: 2 }}>
                   {
-                    description.length > 20 ? description.split(" ").slice(0, 3).join(" ") + "..." 
+                    description.length > 100 ? `${description.substring(0, 100)}...`
                     : description || "This project is created by the onboarding process "
                   }
                 </Typography>
@@ -143,7 +143,8 @@ const DevAPICard: React.FC<CardProps> = ({
               variant="subtitle1"
               sx={{ margin: 1.5, marginLeft: 2.5 }}
               color="text.secondary">
-              {createdOn?.slice(0, 10) || "Updated"}
+              {createdOn && new Date(createdOn).toLocaleDateString() || "Updated"}
+                {/* or new Date(date).toDateString() : this will include the day */}
             </Typography>
           </React.Fragment>
         </Card>
@@ -153,22 +154,11 @@ const DevAPICard: React.FC<CardProps> = ({
 };
 
 const useStyles = makeStyles({
-  paper: {
-    "@media screen and (max-width: 500px)": {
-      scale: 0.87,
-    },
-    "@media screen and (max-width: 400px)": {
-      scale: 0.78,
-    },
-    "@media screen and (max-width: 375px)": {
-      scale: 0.75,
-    },
-  },
+  paper: {},
+  card: {
+    width: "100%",
+    height: "100%"
+  }
 });
 
 export default DevAPICard;
-
-
-
-        {/* //   {description ||
-                    "This project is created by the onboarding process "} */}

--- a/src/components/DevAPICard.tsx
+++ b/src/components/DevAPICard.tsx
@@ -128,10 +128,10 @@ const DevAPICard: React.FC<CardProps> = ({
                 <Typography
                   variant="h5"
                   component="div"
-                  sx={{fontSize: "16px", fontWeight: "500", mb: 1}}>
+                  sx={{fontSize: "18px", fontWeight: "500", mb: 1}}>
                   {name || "👋 Onboarding Project"}
                 </Typography>
-                <Typography variant="body2" sx={{fontSize: "14px", mb: 2}}>
+                <Typography variant="body2" sx={{mb: 2}}>
                   {
                     description.length > 100 ? `${description.substring(0, 100)}...`
                     : description || "This project is created by the onboarding process "

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,10 @@ input:-webkit-autofill {
   transition: background-color 5000s ease-in-out 0s;
 }
 
+button {
+  font-family: var(--body-font);
+}
+
 ::-webkit-scrollbar {
   width: 6px;
 }


### PR DESCRIPTION
- Change the width property from `minWidth` to `width`
- Changed the truncating method of the description to `substring`
- Changed the date display to a `Date` object